### PR TITLE
DR2-1583 Add file logging.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM openjdk:19-jdk-alpine
-COPY target/scala-2.13/dr2-disaster-recovery.jar /dr2-disaster-recovery.jar
-RUN mkdir -p /poduser/work /poduser/repo && chown -R 1002:1005 /poduser
+COPY target/scala-3.3.3/dr2-disaster-recovery.jar /dr2-disaster-recovery.jar
+RUN mkdir -p /poduser/work /poduser/repo && \
+    chown -R 1002:1005 /poduser && \
+    mkdir /poduser/logs && \
+    touch /poduser/logs/disaster-recovery.log && \
+    chown -R nobody:nobody /poduser/logs && \
+    chmod 644 /poduser/logs/disaster-recovery.log
 USER 1002
+RUN ls -la /poduser/logs
 CMD java -jar /dr2-disaster-recovery.jar

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -7,6 +7,13 @@ appender.console.name = STDOUT
 appender.console.layout.type = JsonTemplateLayout
 appender.console.layout.eventTemplateUri = classpath:EcsLayout.json
 
-rootLogger.level = info
+appender.file.type = File
+appender.file.name = FILE
+appender.file.fileName = /poduser/logs/disaster-recovery.log
+appender.file.layout.type = JsonTemplateLayout
+appender.file.layout.eventTemplateUri = classpath:EcsLayout.json
 
+# Root Logger Configuration
+rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.file.ref = FILE


### PR DESCRIPTION
I can't convince podman to not write the timestamp all over my nice json
and my original plan of having a systemd service which writes a cleaned
log isn't working because systemd decides to spawn multiple processes so
we end up with multiple logs lines.

Rather than trying to work out what's up with it, I've changed the
logging to log to a file. I'll then mount a volume from the host to the
/poduser/logs directory and we should get logs written directly from the
code.
