### PR TITLE
Fix vulnerabilities in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM openjdk:19-jdk-alpine
+FROM alpine
 COPY target/scala-3.3.3/dr2-disaster-recovery.jar /dr2-disaster-recovery.jar
-RUN mkdir -p /poduser/work /poduser/repo /poduser/version && \
+RUN apk update && apk upgrade && apk add openjdk19-jre && \
+    mkdir -p /poduser/work /poduser/repo /poduser/version && \
     chown -R 1002:1005 /poduser && \
     mkdir /poduser/logs && \
     touch /poduser/logs/disaster-recovery.log && \


### PR DESCRIPTION
The openjdk image is behind with its version of alpine and there were a
good few fixes in the newer versions so I've replaced it with the base
alpine image and installed the jre manually. Running apk upgrade gets
the latest versions of packages which usually clears a few CVEs as well.
