### PR TITLE
DR2-1605 Purge corrupted objects.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/OcflService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/OcflService.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives
 
 import cats.effect.IO
-import io.ocfl.api.exception.NotFoundException
+import io.ocfl.api.exception.{CorruptObjectException, NotFoundException}
 import io.ocfl.api.model.{DigestAlgorithm, ObjectVersionId, VersionInfo}
 import io.ocfl.api.{OcflConfig, OcflObjectUpdater, OcflOption, OcflRepository}
 import io.ocfl.core.OcflRepositoryBuilder
@@ -64,6 +64,12 @@ class OcflService(ocflRepository: OcflRepository) {
 
             case Failure(_: NotFoundException) =>
               objectMap + ("missingObjects" -> (obj :: missedObjects)) // Information Object doesn't exist
+            case Failure(coe: CorruptObjectException) =>
+              ocflRepository.purgeObject(objectId.toString)
+              throw new Exception(
+                s"$objectId is corrupt. the object has been purged and the error will be rethrown so the process can try again",
+                coe
+              )
             case Failure(unexpectedError) =>
               throw new Exception(
                 s"'getObject' returned an unexpected error '$unexpectedError' when called with object id $objectId"

--- a/src/main/scala/uk/gov/nationalarchives/OcflService.scala
+++ b/src/main/scala/uk/gov/nationalarchives/OcflService.scala
@@ -67,7 +67,7 @@ class OcflService(ocflRepository: OcflRepository) {
             case Failure(coe: CorruptObjectException) =>
               ocflRepository.purgeObject(objectId.toString)
               throw new Exception(
-                s"$objectId is corrupt. the object has been purged and the error will be rethrown so the process can try again",
+                s"Object $objectId is corrupt. The object has been purged and the error will be rethrown so the process can try again",
                 coe
               )
             case Failure(unexpectedError) =>

--- a/src/test/scala/uk/gov/nationalarchives/OcflServiceTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/OcflServiceTest.scala
@@ -149,7 +149,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     }
 
     ex.getMessage should equal(
-      s"$id is corrupt. the object has been purged and the error will be rethrown so the process can try again"
+      s"Object $id is corrupt. The object has been purged and the error will be rethrown so the process can try again"
     )
     objectIdCaptor.getValue should equal(id.toString)
   }


### PR DESCRIPTION
It is possible to end up with a corrupted object if SIGKILL is sent
while the OCFL library is writing.

If this happens, we now check for the corrupted object exception, purge
the corrupted version from the repository and rethrow the exception.
This will cause the message to be picked up again and this time, after
the purge, the write should complete successfully.

I've added in a test for it.
