### PR TITLE
Prevent infinite loop.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: DR2 Tag and pre deploy
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 permissions:
   id-token: write
   contents: write
@@ -11,6 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - id: build
         run: |
           git config --global user.email digitalpreservation@nationalarchives.gov.uk

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,0 +1,14 @@
+name: Deploy if not a version bump PR
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.base_ref == 'main' && github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'Version bump') }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh workflow run build.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
We're not checking if it's a version bump PR before we deploy so we're
stuck in an infinite loop.

Also, we're not signing commits
