### PR TITLE
upgrade jre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 COPY target/scala-3.4.2/dr2-disaster-recovery.jar /dr2-disaster-recovery.jar
-RUN apk update && apk upgrade && apk add openjdk19-jre && \
+RUN apk update && apk upgrade && apk add openjdk21-jre && \
     mkdir -p /poduser/work /poduser/repo /poduser/version && \
     chown -R 1002:1005 /poduser && \
     mkdir /poduser/logs && \

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
-ThisBuild / version := "0.0.6-SNAPSHOT"
+ThisBuild / version := "0.0.7-SNAPSHOT"
 


### PR DESCRIPTION
JDK 19 is not available on the latest version of the alpine
repositories. This is the lowest version I could find.

It should still work.