### PR TITLE
DR2-1766 Fixes for DR following UAT run

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ If the disaster recovery process completes successfully, the messages are delete
 If any messages in a batch fail, all messages are left to try again. This avoids having to work out which ones were
 successful which could be error-prone.
 
+#### Parallel processing
+Each message is processed in parallel except for writing to the OCFL repository. 
+The OCFL library will throw an exception if you try to write to the same object at the same time so there is a single semaphore to prevent two fibers writing at the same time.
+All other processes, fetching the data from Preservica and deleting the SQS messages are processed in parallel.
+
 ### Infrastructure
 
 This will be hosted on a machine at Kew rather than in the cloud so the only infrastructure resource needed is the

--- a/disaster-recovery-builder/src/main/scala/uk/gov/nationalarchives/builder/Ocfl.scala
+++ b/disaster-recovery-builder/src/main/scala/uk/gov/nationalarchives/builder/Ocfl.scala
@@ -66,8 +66,9 @@ object Ocfl:
           }
         }
 
-      val ingestDateTime = ioMetadata.map { metadata =>
-        Instant.parse((metadata \ "Metadata" \ "Content" \ "Source" \ "IngestDateTime").text)
+      val ingestDateTime = ioMetadata.flatMap { metadata =>
+        val dateTimeText = (metadata \ "Metadata" \ "Content" \ "Source" \ "IngestDateTime").text
+        if dateTimeText.isBlank then None else Option(Instant.parse(dateTimeText))
       }
 
       files.filter(_.getPath.contains(s"CO_Metadata.xml")).map { coMetadataFile =>

--- a/disaster-recovery/src/main/scala/uk/gov/nationalarchives/disasterrecovery/Main.scala
+++ b/disaster-recovery/src/main/scala/uk/gov/nationalarchives/disasterrecovery/Main.scala
@@ -85,8 +85,8 @@ object Main extends IOApp {
           _ <- logger.info(messageResponses.flatMap(_.message.map(_.messageText)).mkString(","))
           fibers <- dedupeMessages(messageResponses).parTraverse(processor.process(_).start)
           fiberResults <- fibers.traverse(_.join)
-          _ <- logger.info(s"${fiberResults.count(_.isSuccess)} messages processed successfully")
-          _ <- logger.info(s"${fiberResults.count(_.isError)} messages failed")
+          _ <- logger.info(s"${fiberResults.count(_.isSuccess)} messages out of ${fibers.length} unique messages processed successfully")
+          _ <- logger.info(s"${fiberResults.count(_.isError)} messages out of ${fibers.length} unique messages failed")
           _ <- fiberResults traverse {
             case Outcome.Errored(e) => logError(e) >> IO.unit
             case _                  => IO.unit

--- a/disaster-recovery/src/main/scala/uk/gov/nationalarchives/disasterrecovery/Processor.scala
+++ b/disaster-recovery/src/main/scala/uk/gov/nationalarchives/disasterrecovery/Processor.scala
@@ -135,7 +135,7 @@ class Processor(
 
   private def createMetadataFileName(entityTypeShort: String) = s"${entityTypeShort}_Metadata.xml"
 
-  private def toDisasterRecoveryObject(message: Option[ReceivedSnsMessage]): IO[List[DisasterRecoveryObject]] = message match {
+  private def toDisasterRecoveryObject(potentialMessage: Option[ReceivedSnsMessage]): IO[List[DisasterRecoveryObject]] = potentialMessage match {
     case Some(IoReceivedSnsMessage(ref, _)) =>
       for {
         entity <- fromType[IO](InformationObject.entityTypeShort, ref, None, None, deleted = false)
@@ -289,7 +289,7 @@ class Processor(
         snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).map(_ => ())
       }
       _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
-      deleteResponse <- deleteMessage(messageResponse.receiptHandle)
+      _ <- deleteMessage(messageResponse.receiptHandle)
     } yield ()
 }
 object Processor {

--- a/disaster-recovery/src/main/scala/uk/gov/nationalarchives/disasterrecovery/Processor.scala
+++ b/disaster-recovery/src/main/scala/uk/gov/nationalarchives/disasterrecovery/Processor.scala
@@ -36,8 +36,8 @@ class Processor(
     snsClient: DASNSClient[IO]
 ) {
   private val newlineAndIndent = "\n          "
-  private def deleteMessages(receiptHandles: List[String]): IO[List[DeleteMessageResponse]] =
-    receiptHandles.map(handle => sqsClient.deleteMessage(config.sqsQueueUrl, handle)).sequence
+  private def deleteMessage(receiptHandle: String): IO[DeleteMessageResponse] =
+    sqsClient.deleteMessage(config.sqsQueueUrl, receiptHandle)
 
   private def dedupeMessages(messages: List[ReceivedSnsMessage]): List[ReceivedSnsMessage] = messages.distinctBy(_.messageText)
 
@@ -135,8 +135,8 @@ class Processor(
 
   private def createMetadataFileName(entityTypeShort: String) = s"${entityTypeShort}_Metadata.xml"
 
-  private def toDisasterRecoveryObject(message: ReceivedSnsMessage): IO[List[DisasterRecoveryObject]] = message match {
-    case IoReceivedSnsMessage(ref, _) =>
+  private def toDisasterRecoveryObject(message: Option[ReceivedSnsMessage]): IO[List[DisasterRecoveryObject]] = message match {
+    case Some(IoReceivedSnsMessage(ref, _)) =>
       for {
         entity <- fromType[IO](InformationObject.entityTypeShort, ref, None, None, deleted = false)
         metadataFileName = createMetadataFileName(InformationObject.entityTypeShort)
@@ -151,7 +151,7 @@ class Processor(
           )
         }
       } yield metadataObject
-    case CoReceivedSnsMessage(ref, _) =>
+    case Some(CoReceivedSnsMessage(ref, _)) =>
       for {
         bitstreamInfoPerCo <- entityClient.getBitstreamInfo(ref)
         entity <- fromType[IO](
@@ -207,6 +207,7 @@ class Processor(
           removeFileExtension(bitStreamInfo.name)
         )
       } ++ metadata
+    case None => IO.pure(Nil)
   }
 
   private def download(disasterRecoveryObject: DisasterRecoveryObject) = disasterRecoveryObject match {
@@ -234,9 +235,11 @@ class Processor(
     if (bitstreamName.contains(".")) bitstreamName.split('.').dropRight(1).mkString(".") else bitstreamName
   }
 
-  private def getSourceIdFromIdentifierNodes(identifiers: Seq[Node]) = identifiers.collect {
-    case identifier if (identifier \ "Type").text == "SourceID" => (identifier \ "Value").text
-  }.head
+  private def getSourceIdFromIdentifierNodes(identifiers: Seq[Node]) = identifiers
+    .collectFirst {
+      case identifier if (identifier \ "Type").text == "SourceID" => (identifier \ "Value").text
+    }
+    .getOrElse("")
 
   private def generateSnsMessage(
       obj: DisasterRecoveryObject,
@@ -263,17 +266,12 @@ class Processor(
       .apply(message)
   }
 
-  def process(messageResponses: List[MessageResponse[Option[ReceivedSnsMessage]]]): IO[Unit] =
+  def process(messageResponse: MessageResponse[Option[ReceivedSnsMessage]]): IO[Unit] =
     for {
       logger <- Slf4jLogger.create[IO]
-      _ <- logger.info(s"Processing ${messageResponses.length} messages")
-      messages = dedupeMessages(messageResponses.flatMap(_.message))
-      _ <- logger.info(s"Size after de-duplication ${messages.length}")
-      _ <- logger.info(messages.map(_.messageText).mkString(","))
-      disasterRecoveryObjects <- messages.map(toDisasterRecoveryObject).sequence
-      flatDisasterRecoveryObjects = disasterRecoveryObjects.flatten
+      disasterRecoveryObjects <- toDisasterRecoveryObject(messageResponse.message)
 
-      missingAndChangedObjects <- ocflService.getMissingAndChangedObjects(flatDisasterRecoveryObjects)
+      missingAndChangedObjects <- ocflService.getMissingAndChangedObjects(disasterRecoveryObjects)
 
       missingObjectsPaths <- missingAndChangedObjects.missingObjects.map(download).sequence
       changedObjectsPaths <- missingAndChangedObjects.changedObjects.map(download).sequence
@@ -291,7 +289,7 @@ class Processor(
         snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).map(_ => ())
       }
       _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
-      _ <- deleteMessages(messageResponses.map(_.receiptHandle))
+      deleteResponse <- deleteMessage(messageResponse.receiptHandle)
     } yield ()
 }
 object Processor {

--- a/disaster-recovery/src/test/scala/uk/gov/nationalarchives/disasterrecovery/MainTest.scala
+++ b/disaster-recovery/src/test/scala/uk/gov/nationalarchives/disasterrecovery/MainTest.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.disasterrecovery
 
-import cats.effect.IO
+import cats.effect.{IO, Outcome}
+import cats.effect.std.Semaphore
 import cats.effect.unsafe.implicits.global
 import io.ocfl.api.OcflRepository
 import io.ocfl.api.model.ObjectVersionId
@@ -28,11 +29,20 @@ import scala.xml.Utility.trim
 import scala.xml.XML
 
 class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
+
+  private def getError(
+      sqsClient: DASQSClient[IO],
+      config: Config,
+      processor: Processor
+  ): Throwable = runDisasterRecovery(sqsClient, config, processor).head match
+    case Outcome.Errored(e) => e
+    case _                  => throw new Exception("Expected an error but none found")
+
   private def runDisasterRecovery(
       sqsClient: DASQSClient[IO],
       config: Config,
       processor: Processor
-  ): Unit = Main.runDisasterRecovery(sqsClient, config, processor).compile.drain.unsafeRunSync()
+  ): List[Outcome[IO, Throwable, Unit]] = Main.runDisasterRecovery(sqsClient, config, processor).compile.toList.unsafeRunSync().flatten
 
   "runDisasterRecovery" should "write a new version and new IO metadata object, to the correct location in the repository " +
     "if it doesn't already exist" in {
@@ -177,15 +187,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
         utils.xmlValidator,
         utils.snsClient
       )
-    val err: Throwable =
-      Main
-        .runDisasterRecovery(utils.sqsClient, utils.config, processor)
-        .compile
-        .drain
-        .attempt
-        .unsafeRunSync()
-        .left
-        .value
+    val err: Throwable = getError(utils.sqsClient, utils.config, processor)
+
     err.getMessage must equal("Error getting metadata")
   }
 
@@ -204,15 +207,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     )
     val utils = new MainTestUtils(List(ContentObject), 0, bitstreamInfo1Responses = bitstreamInfo)
 
-    val err: Throwable =
-      Main
-        .runDisasterRecovery(utils.sqsClient, utils.config, utils.processor)
-        .compile
-        .drain
-        .attempt
-        .unsafeRunSync()
-        .left
-        .value
+    val err: Throwable = getError(utils.sqsClient, utils.config, utils.processor)
     err.getMessage must equal("Cannot get IO reference from CO")
   }
 
@@ -237,15 +232,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     )
     val coId = utils.coId1
 
-    val err: Throwable =
-      Main
-        .runDisasterRecovery(utils.sqsClient, utils.config, utils.processor)
-        .compile
-        .drain
-        .attempt
-        .unsafeRunSync()
-        .left
-        .value
+    val err: Throwable = getError(utils.sqsClient, utils.config, utils.processor)
+
     err.getMessage must equal(
       s"$coId belongs to more than 1 representation type: Preservation_1, Access_1"
     )
@@ -380,7 +368,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
       repo.getObject(ioId.toHeadVersion).containsFile(path) must be(true)
     }
 
-    utils.latestObjectVersion(repo, ioId) must equal(2)
+    utils.latestObjectVersion(repo, ioId) must equal(4)
   }
 
   "runDisasterRecovery" should "only write one version if there are two identical CO messages" in {
@@ -400,8 +388,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
 
     val processor =
       new Processor(utils.config, sqsClient, utils.ocflService, preservicaClient, utils.xmlValidator, utils.snsClient)
-    val err: Throwable =
-      Main.runDisasterRecovery(sqsClient, utils.config, processor).compile.drain.attempt.unsafeRunSync().left.value
+
+    val err: Throwable = getError(sqsClient, utils.config, processor)
     err.getMessage must equal("Error getting bitstream info")
   }
 
@@ -515,8 +503,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
 
     val repo = mock[OcflRepository]
     when(repo.getObject(any[ObjectVersionId])).thenThrow(new RuntimeException("Unexpected Exception"))
-
-    val ocflService = new OcflService(repo)
+    val semaphore: Semaphore[IO] = Semaphore[IO](1).unsafeRunSync()
+    val ocflService = new OcflService(repo, semaphore)
     val processor =
       new Processor(
         utils.config,
@@ -527,9 +515,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
         utils.snsClient
       )
 
-    val ex = intercept[Exception] {
-      runDisasterRecovery(utils.sqsClient, utils.config, processor)
-    }
+    val ex: Throwable = getError(utils.sqsClient, utils.config, processor)
+
     ex.getMessage must equal(
       s"'getObject' returned an unexpected error 'java.lang.RuntimeException: Unexpected Exception' when called with object id $ioId"
     )

--- a/disaster-recovery/src/test/scala/uk/gov/nationalarchives/disasterrecovery/testUtils/ExternalServicesTestUtils.scala
+++ b/disaster-recovery/src/test/scala/uk/gov/nationalarchives/disasterrecovery/testUtils/ExternalServicesTestUtils.scala
@@ -643,9 +643,6 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       idWithSourceAndDestPathsCaptor.getAllValues.asScala.toList.flatten.zipWithIndex.foreach { case (capturedIdWithSourceAndDestPath, index) =>
         val expectedIdWithSourceAndDestPath = expectedIdsWithSourceAndDestPath(index)
         capturedIdWithSourceAndDestPath.id should equal(expectedIdWithSourceAndDestPath.id)
-        println("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAaa")
-        println(capturedIdWithSourceAndDestPath.sourceNioFilePath.toString)
-        println(expectedIdWithSourceAndDestPath.sourceNioFilePath)
         capturedIdWithSourceAndDestPath.sourceNioFilePath.toString
           .endsWith(expectedIdWithSourceAndDestPath.sourceNioFilePath.toString) should equal(true)
         capturedIdWithSourceAndDestPath.destinationPath should equal(expectedIdWithSourceAndDestPath.destinationPath)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
   lazy val ocfl = "io.ocfl" % "ocfl-java-core" % "2.2.0"
-  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.87"
+  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.89"
   lazy val pureConfigCatsEffect = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig-core" % pureConfigVersion
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.18.0"


### PR DESCRIPTION
SourceID may not be populated. This will default to empty string.

The largest change is to the process method. This no longer processes
the whole list of messages.
The problem was that if one message failed, the whole batch failed and
was sent to the DLQ so we had healthy messages in the DLQ.

The process method now takes a single message and these are run in a
loop. To try to make this faster, I created different fibers for each
message and these run in parallel. You can't update the same OCFL object
in parallel without it getting upset so there's a semaphore to stop
this.

I've added in some more logging as well which I'll leave for now and
remove if it isn't useful.
